### PR TITLE
'RSGCore.Functions.HasItem' API Bug Fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -24,6 +24,7 @@ local function HasItem(items, amount)
     local totalItems = #items
     local count = 0
     local kvIndex = 2
+    local quantity = tonumber(amount)
 	if isTable and not isArray then
         totalItems = 0
         for _ in pairs(items) do totalItems += 1 end
@@ -33,7 +34,7 @@ local function HasItem(items, amount)
         if isTable then
             for k, v in pairs(items) do
                 local itemKV = {k, v}
-                if itemData and itemData.name == itemKV[kvIndex] and ((amount and itemData.amount >= amount) or (not isArray and itemData.amount >= v) or (not amount and isArray)) then
+                if itemData and itemData.name == itemKV[kvIndex] and ((quantity and itemData.amount >= quantity) or (not isArray and itemData.amount >= v) or (not quantity and isArray)) then
                     count += 1
                 end
             end
@@ -41,7 +42,7 @@ local function HasItem(items, amount)
                 return true
             end
         else -- Single item as string
-            if itemData and itemData.name == items and (not amount or (itemData and amount and itemData.amount >= amount)) then
+            if itemData and itemData.name == items and (not quantity or (itemData and quantity and itemData.amount >= quantity)) then
                 return true
             end
         end

--- a/server/main.lua
+++ b/server/main.lua
@@ -424,6 +424,7 @@ local function HasItem(source, items, amount)
     local totalItems = #items
     local count = 0
     local kvIndex = 2
+    local quantity = tonumber(amount)
     if isTable and not isArray then
         totalItems = 0
         for _ in pairs(items) do totalItems += 1 end
@@ -433,7 +434,7 @@ local function HasItem(source, items, amount)
         for k, v in pairs(items) do
             local itemKV = {k, v}
             local item = GetItemByName(source, itemKV[kvIndex])
-            if item and ((amount and item.amount >= amount) or (not isArray and item.amount >= v) or (not amount and isArray)) then
+            if item and ((quantity and item.amount >= quantity) or (not isArray and item.amount >= v) or (not quantity and isArray)) then
                 count += 1
             end
         end
@@ -442,7 +443,7 @@ local function HasItem(source, items, amount)
         end
     else -- Single item as string
         local item = GetItemByName(source, items)
-        if item and (not amount or (item and amount and item.amount >= amount)) then
+        if item and (not quantity or (item and quantity and item.amount >= quantity)) then
             return true
         end
     end


### PR DESCRIPTION
Some scripts sent 'amount' as string and causing severe script error like this:

> [script:rsg-inventory] SCRIPT ERROR: @rsg-inventory/server/main.lua:445: attempt to compare string with number [script:rsg-inventory] > handler (@rsg-vendor/server/main.lua:138)
> [     script:rsg-core] SCRIPT ERROR: citizen:/scripting/lua/scheduler.lua:501:
> [     script:rsg-core]  An error occurred while calling export `HasItem` in resource `rsg-inventory`:

To mitigate the issue, we need to make sure 'amount' is a number and not a string.