### PR TITLE
feat: add custom descriptions to generic items

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -112,7 +112,7 @@ local function LoadInventory(source, citizenid)
                     amount = item.amount,
                     info = item.info or '',
                     label = itemInfo['label'],
-                    description = itemInfo['description'] or '',
+                    description = (item.info and item.info.description) or item.description or itemInfo['description'] or '',
                     weight = itemInfo['weight'],
                     type = itemInfo['type'],
                     unique = itemInfo['unique'],
@@ -287,7 +287,7 @@ local function AddItem(source, item, amount, slot, info, created)
             else
                 for i = 1, Config.MaxInventorySlots, 1 do
                     if Player.PlayerData.items[i] == nil then
-                        Player.PlayerData.items[i] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = i, combinable = itemInfo['combinable'], created = itemInfo['created'] }
+                        Player.PlayerData.items[i] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = (info and info.description) or itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = i, combinable = itemInfo['combinable'], created = itemInfo['created'] }
                         Player.Functions.SetPlayerData("items", Player.PlayerData.items)
                         if Player.Offline then return true end
                         TriggerEvent('rsg-log:server:CreateLog', 'playerinventory', 'AddItem', 'green', '**' .. GetPlayerName(source) .. ' (citizenid: ' .. Player.PlayerData.citizenid .. ' | id: ' .. source .. ')** got item: [slot:' .. i .. '], itemname: ' .. Player.PlayerData.items[i].name .. ', added amount: ' .. amount .. ', new total amount: ' .. Player.PlayerData.items[i].amount)
@@ -296,7 +296,7 @@ local function AddItem(source, item, amount, slot, info, created)
                 end
             end
         elseif not itemInfo['unique'] and slot or slot and Player.PlayerData.items[slot] == nil then
-            Player.PlayerData.items[slot] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = slot, combinable = itemInfo['combinable'], created = itemInfo['created'] }
+            Player.PlayerData.items[slot] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = (info and info.description) or itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = slot, combinable = itemInfo['combinable'], created = itemInfo['created'] }
             Player.Functions.SetPlayerData("items", Player.PlayerData.items)
 
             if Player.Offline then return true end
@@ -307,7 +307,7 @@ local function AddItem(source, item, amount, slot, info, created)
         elseif itemInfo['unique'] or (not slot or slot == nil) or itemInfo['type'] == 'weapon' then
                     for i = 1, Config.MaxInventorySlots, 1 do
                         if Player.PlayerData.items[i] == nil then
-                            Player.PlayerData.items[i] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = i, combinable = itemInfo['combinable'] }
+                            Player.PlayerData.items[i] = { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = (info and info.description) or itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = i, combinable = itemInfo['combinable'] }
                             Player.Functions.SetPlayerData("items", Player.PlayerData.items)
 
                             if Player.Offline then return true end
@@ -617,7 +617,7 @@ local function SetupShopItems(shopItems)
                     amount = tonumber(item.amount),
                     info = item.info or "",
                     label = itemInfo["label"],
-                    description = itemInfo["description"] or "",
+                    description = (item.info and item.info.description) or itemInfo["description"] or "",
                     weight = itemInfo["weight"],
                     type = itemInfo["type"],
                     unique = itemInfo["unique"],
@@ -651,7 +651,7 @@ local function GetStashItems(stashId)
                 amount = tonumber(item.amount),
                 info = item.info or "",
                 label = itemInfo["label"],
-                description = itemInfo["description"] or "",
+                description = (item.info and item.info.description) or itemInfo["description"] or "",
                 weight = itemInfo["weight"],
                 type = itemInfo["type"],
                 unique = itemInfo["unique"],
@@ -703,7 +703,7 @@ local function AddToStash(stashId, slot, otherslot, itemName, amount, info, crea
                 amount = amount,
                 info = info or "",
                 label = itemInfo["label"],
-                description = itemInfo["description"] or "",
+                description = (info and info.description) or itemInfo["description"] or "",
                 weight = itemInfo["weight"],
                 type = itemInfo["type"],
                 unique = itemInfo["unique"],
@@ -721,7 +721,7 @@ local function AddToStash(stashId, slot, otherslot, itemName, amount, info, crea
                 amount = amount,
                 info = info or "",
                 label = itemInfo["label"],
-                description = itemInfo["description"] or "",
+                description = (info and info.description) or itemInfo["description"] or "",
                 weight = itemInfo["weight"],
                 type = itemInfo["type"],
                 unique = itemInfo["unique"],
@@ -737,7 +737,7 @@ local function AddToStash(stashId, slot, otherslot, itemName, amount, info, crea
                 amount = amount,
                 info = info or "",
                 label = itemInfo["label"],
-                description = itemInfo["description"] or "",
+                description = (info and info.description) or itemInfo["description"] or "",
                 weight = itemInfo["weight"],
                 type = itemInfo["type"],
                 unique = itemInfo["unique"],
@@ -789,7 +789,7 @@ local function AddToDrop(dropId, slot, itemName, amount, info, created)
             amount = amount,
             info = info or "",
             label = itemInfo["label"],
-            description = itemInfo["description"] or "",
+            description = (info and info.description) or itemInfo["description"] or "",
             weight = itemInfo["weight"],
             type = itemInfo["type"],
             unique = itemInfo["unique"],
@@ -885,7 +885,7 @@ local function CreateNewDrop(source, fromSlot, toSlot, itemAmount, created)
             amount = itemAmount,
             info = itemData.info or "",
             label = itemInfo["label"],
-            description = itemInfo["description"] or "",
+            description = (itemData.info and itemData.info.description) or itemInfo["description"] or "",
             weight = itemInfo["weight"],
             type = itemInfo["type"],
             unique = itemInfo["unique"],
@@ -1971,7 +1971,7 @@ RegisterNetEvent('inventory:server:dropOnGround', function(thissource, itemInfos
             amount = itemAmount,
             info = info,
             label = itemInfo["label"],
-            description = itemInfo["description"] or "",
+            description = (info and info.description) or itemInfo["description"] or "",
             weight = itemInfo["weight"],
             type = itemInfo["type"],
             unique = itemInfo["unique"],


### PR DESCRIPTION
## Overview
With this Pull Request, I argue for the use of an optional property in the items info property called 'description'. This `info.description` is prioritized above `RSGCore.Shared.Item[itemName].description` if set. 

## Problem Addressed
The possibilities of manipulating the item's descriptions are underused. It was possible to set it via `SetItemData` but it is never saved to the database in `SaveInventory` nor was considered in `LoadInventory` nor could it be specified for a slot or item when there are multiple with the same name. Therefore, all descriptions would be dropped after the session ends. Without touching too much logic, I propose this solution to keep it an optional, non-breaking feature. 

Actually manipulating the items description would result in breaking changes to framework functions. E.g. `AddToStash` is not receiving the actual item but rather some information, missing the description. Therefore, there would be changes to this function. But as all functions already receive `info`, no changes to those functions are needed.

## Solution Overview
Whenever a description is set, it will first check if there is an `info.description` set and take this if set. Otherwise it uses the old logic and by using the default items description from the `RSGCore.Shared.Item` list.

## Impact
I would argue that the impact should be minimal to other features and systems. The `info` property is already part of the system and all changes check if the optional value exists, and if not use the old way to determine the items description. 

## Background Information
I am actually new to RSG. Maybe I am missing an intended way. I want to build a framework wrapper to make scripts compatible with the RSG framework. Some of these scripts make heavy use of metadata and custom descriptions. I also thought about creating programmatically new items for each item variation I require, but this somehow feels wrong. I would also argue, that simply for making cross framework interoperability easier, this would be a good addition, as this is a feature available in other frameworks for generic items and is easily also achievable with these proposed changes. 


## Demonstration Video
https://medal.tv/de/games/red-dead-2/clips/23HcKqPhgBH-a-/d1337o5IIMF6?invite=cr-MSxFelIsMTYzMzExMTA5LA

This is currently all I tested as I currently have no one to trade with, and I am not sure how to create a stash, to be honest. If this would also be a wanted feature, and you would consider these changes, I can try to also test these interactions as well.