### PR TITLE
Item decay, ui tweaks, fixes

### DIFF
--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -52,6 +52,10 @@ RegisterNetEvent('rsg-inventory:client:ItemBox', function(itemData, type, amount
             type = type,
             amount = amount
         })
+        
+        if type == 'remove' then
+            TriggerServerEvent('rsg-inventory:server:updateHotbar')
+        end
     end
 
     local lastItemBoxCall = LocalPlayer.state.lastItemBoxCall or 0
@@ -67,10 +71,6 @@ RegisterNetEvent('rsg-inventory:client:ItemBox', function(itemData, type, amount
             sendItemBox()
         end, true)
         lastItemBoxCall = currentTime + delay
-    end
-
-    if type == 'remove' then
-        TriggerServerEvent('rsg-inventory:server:updateHotbar')
     end
 
     LocalPlayer.state.lastItemBoxCall = lastItemBoxCall

--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -53,7 +53,7 @@ RegisterNetEvent('rsg-inventory:client:ItemBox', function(itemData, type, amount
             amount = amount
         })
         
-        if type == 'remove' then
+        if type == 'remove' or type == 'add' then
             TriggerServerEvent('rsg-inventory:server:updateHotbar')
         end
     end

--- a/config/config.lua
+++ b/config/config.lua
@@ -37,6 +37,7 @@ Config = {
     ShopsEnableBuyback = true, -- enable shops buying items for fraction of selling price
     ShopsBuybackPriceMultiplier = 0.1, -- fraction of buyback price (1 = full price, 0.1 = 10% of selling price)
     ShopsEnableBuybackStockLimit = true, -- shops won't buyback item if default stock amount is reached
+    ShopsMinimumSellQuality = 50, -- shops won't buyback item if item quality drops to this value (set -1 to disable)
 
     VendingObjects = {
         `s_inv_whiskey02x`,

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-inventory'
-version '2.2.8'
+version '2.2.9'
 
 shared_scripts {
     '@ox_lib/init.lua',

--- a/html/app.js
+++ b/html/app.js
@@ -981,7 +981,7 @@ const InventoryContainer = Vue.createApp({
 
             if (item.info && Object.keys(item.info).length > 0) {
                 for (const [key, value] of Object.entries(item.info)) {
-                    if (key !== "description") {
+                    if (key !== "description" && key !== "lastUpdate") {
                         let valueStr = value;
                         if (key === "attachments") {
                             valueStr = Object.keys(value).length > 0 ? "true" : "false";

--- a/html/app.js
+++ b/html/app.js
@@ -85,6 +85,7 @@ const InventoryContainer = Vue.createApp({
                 // Hotbar
                 showHotbar: false,
                 hotbarItems: [],
+                wasHotbarEnabled: false,
                 // Notification box
                 showNotification: false,
                 notificationText: "",
@@ -125,7 +126,10 @@ const InventoryContainer = Vue.createApp({
         },
         openInventory(data) {
             if (this.showHotbar) {
+                this.wasHotbarEnabled = true;
                 this.toggleHotbar(false);
+            } else {
+                this.wasHotbarEnabled = false;
             }
 
             this.isInventoryOpen = true;
@@ -206,9 +210,24 @@ const InventoryContainer = Vue.createApp({
         },
         async closeInventory() {
             let inventoryName = this.otherInventoryName;
+            const wasHotbarEnabled = this.wasHotbarEnabled;
+            let hotbarItems = []
+            if (wasHotbarEnabled) {
+                hotbarItems = Array(5).fill(null).map((_, index) => {
+                    const item = this.playerInventory[index + 1];
+                    return item !== undefined ? item : null;
+                });
+            }
+
             Object.assign(this, this.getInitialState());
             try {
                 await axios.post("https://rsg-inventory/CloseInventory", { name: inventoryName });
+                if (wasHotbarEnabled) {
+                    this.toggleHotbar({
+                        open: true,
+                        items: hotbarItems,
+                    });
+                }
             } catch (error) {
                 console.error("Error closing inventory:", error);
             }

--- a/html/index.html
+++ b/html/index.html
@@ -97,7 +97,7 @@
                             <div v-if="isShopInventory && getItemInSlot(slot, 'other')" class="item-price">
                                 <p>${{ getItemInSlot(slot, 'other').price }}</p>
                             </div>
-                            <div class="item-slot-durability" v-if="getItemInSlot(slot, 'other')">
+                            <div class="item-slot-durability" v-if="getItemInSlot(slot, 'other') && 'quality' in getItemInSlot(slot, 'other').info">
                                 <div
                                     class="item-slot-durability-fill"
                                     v-if="getItemInSlot(slot, 'other').info && 'quality' in getItemInSlot(slot, 'other').info"
@@ -129,7 +129,7 @@
                         <div class="item-slot-amount" v-if="getHotbarItemInSlot(slot)">
                             <p>x{{ getHotbarItemInSlot(slot).amount }}</p>
                         </div>
-                        <div class="item-slot-durability" v-if="getHotbarItemInSlot(slot)">
+                        <div class="item-slot-durability" v-if="getHotbarItemInSlot(slot) && 'quality' in getHotbarItemInSlot(slot).info">
                             <div
                                 class="item-slot-durability-fill"
                                 v-if="getHotbarItemInSlot(slot).info && 'quality' in getHotbarItemInSlot(slot).info"

--- a/html/index.html
+++ b/html/index.html
@@ -43,7 +43,7 @@
                             <div class="item-slot-amount" v-if="getItemInSlot(slot, 'player')">
                                 <p>x{{ getItemInSlot(slot, 'player').amount }}</p>
                             </div>
-                            <div class="item-slot-durability" v-if="getItemInSlot(slot, 'player')">
+                            <div class="item-slot-durability" v-if="getItemInSlot(slot, 'player') && getItemInSlot(slot, 'player').info && 'quality' in getItemInSlot(slot, 'player').info">
                                 <div
                                     class="item-slot-durability-fill"
                                     v-if="getItemInSlot(slot, 'player').info && 'quality' in getItemInSlot(slot, 'player').info"

--- a/html/main.css
+++ b/html/main.css
@@ -218,15 +218,12 @@ div {
 .item-slot-label {
     position: absolute;
     white-space: nowrap;
-    bottom: 0;
+    bottom: 6px;
     height: 1.5vh;
     width: 100%;
-    background-color: #cccccc;
     display: flex;
     justify-content: center;
     align-items: center;
-    box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1), 0 2px 2px rgba(0, 0, 0, 0.2);
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.1));
 }
 
 .item-slot-durability {
@@ -256,15 +253,23 @@ div {
 
 .item-slot-label > p {
     text-transform: uppercase;
+    color: white;
+    font-size: 0.8vh;
     font-weight: bold;
-    color: #000000;
-    font-size: 1.2vh;
     text-align: center;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     width: 100%; 
     display: block;
+}
+
+.hotbar .item-slot-durability {
+    position: absolute;
+    bottom: 0vh;
+    width: 99%;
+    height: 6px;
+    background-color: #2d2d2d;
 }
 
 /* Weight Bar Styles */
@@ -320,7 +325,7 @@ div {
     display: flex;
     justify-content: center;
     position: fixed;
-    bottom: 2vh;
+    bottom: 14vh;
     left: 50%;
     transform: translate(-50%);
 }

--- a/html/main.css
+++ b/html/main.css
@@ -337,16 +337,18 @@ div {
 }
 
 .notification-title {
+    position: absolute;
     color: white;
     align-self: flex-start;
-    margin-top: 5px;
+    margin-top: 6px;
     margin-left: 5px;
 }
 
 .notification-title p {
     margin: 0;
     padding: 0;
-    font-size: 0.7vh;
+    font-size: 1.2vh;
+    font-weight: bolder;
 }
 
 .required-item-container {

--- a/server/drops/events/events.lua
+++ b/server/drops/events/events.lua
@@ -9,6 +9,7 @@ RegisterNetEvent('rsg-inventory:server:openDrop', function(dropId)
     if drop.isOpen then return end
     local distance = #(playerCoords - drop.coords)
     if distance > 2.5 then return end
+    Inventory.CheckItemsDecay(drop.items)
     local formattedInventory = {
         name = dropId,
         label = dropId,

--- a/server/events/events.lua
+++ b/server/events/events.lua
@@ -94,7 +94,7 @@ RegisterNetEvent('rsg-inventory:server:SetInventoryData', function(fromInventory
 
         if fromId ~= toId then isMove = true end
 
-        if toItem and fromItem.name == toItem.name then
+        if toItem and fromItem.name == toItem.name and fromItem.info.quality == toItem.info.quality then
             if Inventory.RemoveItem(fromId, fromItem.name, toAmount, fromSlot, 'stacked item', isMove) then
                 Inventory.AddItem(toId, toItem.name, toAmount, toSlot, toItem.info, 'stacked item')
             end

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -179,9 +179,9 @@ exports('GetFirstSlotByItem', Inventory.GetFirstSlotByItem)
 Inventory.GetItemBySlot = function(source, slot)
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then return end
-    Inventory.CheckPlayerItemsDecay(Player)
-    local items = Player.PlayerData.items
-    return items[tonumber(slot)]
+    local item = Player.PlayerData.items[tonumber(slot)]
+    if not item then return end
+    return Inventory.CheckPlayerItemDecay(Player, item)
 end
 
 exports('GetItemBySlot', Inventory.GetItemBySlot)

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -8,11 +8,15 @@ Inventory.LoadInventory = function(source, citizenid)
     local loadedInventory = {}
     local missingItems = {}
 
+    local currentTime = os.time()
+
     for _, item in pairs(inventory) do
         if item and item.name then
             local itemInfo = RSGCore.Shared.Items[item.name:lower()]
+            local updated, quality, delete = Inventory.CheckItemDecay(item, itemInfo, currentTime)
+            local check = not (updated and delete and quality <= 0)
 
-            if itemInfo then
+            if itemInfo and check then
                 loadedInventory[item.slot] = {
                     name = itemInfo['name'],
                     amount = item.amount,
@@ -175,6 +179,7 @@ exports('GetFirstSlotByItem', Inventory.GetFirstSlotByItem)
 Inventory.GetItemBySlot = function(source, slot)
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then return end
+    Inventory.CheckPlayerItemsDecay(Player)
     local items = Player.PlayerData.items
     return items[tonumber(slot)]
 end
@@ -262,6 +267,7 @@ exports('GetSlots', Inventory.GetSlots)
 Inventory.GetItemCount = function(source, items)
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then return end
+    Inventory.CheckPlayerItemsDecay(Player)
     local isTable = type(items) == 'table'
     local itemsSet = isTable and {} or nil
     if isTable then
@@ -365,6 +371,8 @@ exports('ClearInventory', Inventory.ClearInventory)
 Inventory.HasItem = function(source, items, amount)
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then return false end
+    Inventory.CheckPlayerItemsDecay(Player)
+
     local isTable = type(items) == 'table'
     local isArray = isTable and table.type(items) == 'array' or false
     local totalItems = isArray and #items or 0
@@ -418,6 +426,8 @@ Inventory.OpenInventoryById = function(source, targetId)
     local TargetPlayer = RSGCore.Functions.GetPlayer(tonumber(targetId))
     if not RSGPlayer or not TargetPlayer then return end
     if Player(targetId).state.inv_busy then Inventory.CloseInventory(targetId) end
+    Inventory.CheckPlayerItemsDecay(RSGPlayer)
+    Inventory.CheckPlayerItemsDecay(TargetPlayer)
     local playerItems = RSGPlayer.PlayerData.items
     local targetItems = TargetPlayer.PlayerData.items
     local formattedInventory = {
@@ -456,6 +466,7 @@ Inventory.OpenInventory = function (source, identifier, data)
 
     if not identifier then
         Player(source).state.inv_busy = true
+        Inventory.CheckPlayerItemsDecay(RSGPlayer)
         TriggerClientEvent('rsg-inventory:client:openInventory', source, RSGPlayer.PlayerData.items)
         return
     end
@@ -472,7 +483,11 @@ Inventory.OpenInventory = function (source, identifier, data)
         return
     end
 
-    if not inventory then inventory = Inventory.InitializeInventory(identifier, data) end
+    if not inventory then 
+        inventory = Inventory.InitializeInventory(identifier, data) 
+    else
+        Inventory.CheckItemsDecay(inventory.items)
+    end
     inventory.maxweight = (data and data.maxweight) or (inventory and inventory.maxweight) or Config.StashSize.maxweight
     inventory.slots = (data and data.slots) or (inventory and inventory.slots) or Config.StashSize.slots
     inventory.label = (data and data.label) or (inventory and inventory.label) or identifier
@@ -485,6 +500,8 @@ Inventory.OpenInventory = function (source, identifier, data)
         slots = inventory.slots,
         inventory = inventory.items
     }
+
+    Inventory.CheckPlayerItemsDecay(RSGPlayer)
     TriggerClientEvent('rsg-inventory:client:openInventory', source, RSGPlayer.PlayerData.items, formattedInventory)
 end
 
@@ -504,6 +521,7 @@ Inventory.AddItem = function(identifier, item, amount, slot, info, reason)
         print('AddItem: Invalid item')
         return false
     end
+
     local inventory, inventoryWeight, inventorySlots
     local player = RSGCore.Functions.GetPlayer(identifier)
 
@@ -526,20 +544,33 @@ Inventory.AddItem = function(identifier, item, amount, slot, info, reason)
         return false
     end
 
+    Inventory.CheckItemsDecay(inventory)
+
+    amount = tonumber(amount) or 1
     local totalWeight = Inventory.GetTotalWeight(inventory)
     if totalWeight + (itemInfo.weight * amount) > inventoryWeight then
         print('AddItem: Not enough weight available')
         return false
     end
 
-    amount = tonumber(amount) or 1
-    local updated = false
+    info = info or {}
+    if itemInfo.decay then
+        info.quality = info.quality or 100
+        info.lastUpdate = info.lastUpdate or os.time()
+    end
 
+    local updated = false
     if not itemInfo.unique then
-        slot = slot or Inventory.GetFirstSlotByItem(inventory, item)
+        if not slot then
+            if itemInfo.decay or info.quality then
+                slot = Inventory.GetFirstSlotByItemWithQuality(inventory, item, info.quality)
+            else
+                slot = Inventory.GetFirstSlotByItem(inventory, item)
+            end
+        end
         if slot then
             for _, invItem in pairs(inventory) do
-                if invItem.slot == slot then
+                if invItem.slot == slot and info.quality == invItem.info.quality then
                     invItem.amount = invItem.amount + amount
                     updated = true
                     break
@@ -558,7 +589,7 @@ Inventory.AddItem = function(identifier, item, amount, slot, info, reason)
         inventory[slot] = {
             name = item,
             amount = amount,
-            info = info or {},
+            info = info,
             label = itemInfo.label,
             description = itemInfo.description or '',
             weight = itemInfo.weight,
@@ -573,7 +604,14 @@ Inventory.AddItem = function(identifier, item, amount, slot, info, reason)
 
         if RSGCore.Shared.SplitStr(item, '_')[1] == 'weapon' then
             if not inventory[slot].info.serie then
-                inventory[slot].info.serie = tostring(RSGCore.Shared.RandomInt(2) .. RSGCore.Shared.RandomStr(3) .. RSGCore.Shared.RandomInt(1) .. RSGCore.Shared.RandomStr(2) .. RSGCore.Shared.RandomInt(3) .. RSGCore.Shared.RandomStr(4))
+                inventory[slot].info.serie = tostring(
+                    RSGCore.Shared.RandomInt(2) .. 
+                    RSGCore.Shared.RandomStr(3) .. 
+                    RSGCore.Shared.RandomInt(1) .. 
+                    RSGCore.Shared.RandomStr(2) .. 
+                    RSGCore.Shared.RandomInt(3) .. 
+                    RSGCore.Shared.RandomStr(4)
+                )
             end
             if not inventory[slot].info.quality then
                 inventory[slot].info.quality = 100
@@ -630,7 +668,9 @@ Inventory.RemoveItem = function(identifier, item, amount, slot, reason, isMove)
         return false
     end
 
-    amount = tonumber(amount)
+    Inventory.CheckItemsDecay(inventory)
+
+    amount = tonumber(amount) or 1
     
     if slot then
         slot = tonumber(slot)
@@ -722,6 +762,7 @@ end
 exports('RemoveItem', Inventory.RemoveItem)
 
 Inventory.GetInventory = function(identifier)
+    Inventory.CheckItemsDecay(Inventories[identifier].items)
     return Inventories[identifier]
 end
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -142,7 +142,6 @@ end
 --- Applies decay to all items in a player's inventory and updates their data.
 --- @param player table The player object.
 Inventory.CheckPlayerItemsDecay = function(player)
-    --- @type boolean, table<number, table>
     local needsUpdate, removedItems = Inventory.CheckItemsDecay(player.PlayerData.items)
 
     if needsUpdate then
@@ -151,4 +150,21 @@ Inventory.CheckPlayerItemsDecay = function(player)
             TriggerClientEvent('rsg-inventory:client:ItemBox', player.PlayerData.source, RSGCore.Shared.Items[item.name], 'remove', item.amount)
         end
     end
+end
+
+--- Applies decay to single item in a player's inventory and updates their data.
+--- @param player table The player object.
+--- @param item table item object.
+Inventory.CheckPlayerItemDecay = function(player, item) 
+    local updated, quality, delete = Inventory.CheckItemDecay(item)
+    if updated then
+        if delete and quality <= 0 then
+            player.PlayerData.items[item.slot] = nil
+            TriggerClientEvent('rsg-inventory:client:ItemBox', player.PlayerData.source, RSGCore.Shared.Items[item.name], 'remove', item.amount)
+        end
+        
+        player.Functions.SetPlayerData('items', player.PlayerData.items)
+    end
+
+    return player.PlayerData.items[item.slot]
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -71,3 +71,84 @@ Inventory.CheckWeapon = function(source, item)
         TriggerClientEvent('rsg-weapons:client:UseWeapon', source, { name = currentWeapon }, false)
     end
 end
+
+-- Retrieves the first slot number that contains an item with the specified name and matches quality
+--- @param items table The table of items to search through.
+--- @param itemName string The name of the item to search for.
+--- @param quality number item quality to match
+--- @return number|nil - The slot number of the first matching item, or nil if no match is found.
+Inventory.GetFirstSlotByItemWithQuality = function(items, itemName, quality)
+    if not items then return end
+    for slot, item in pairs(items) do
+        if item.name:lower() == itemName:lower() and item.info.quality == quality then
+            return tonumber(slot)
+        end
+    end
+    return nil
+end
+
+--- Checks and applies item decay over time.
+--- @param item table The item table.
+--- @param itemInfo table|nil Optional item definition from RSGCore.Shared.Items.
+--- @param currentTime number|nil Optional timestamp (defaults to os.time()).
+--- @return boolean shouldUpdate Whether the item metadata was updated.
+--- @return number|nil newQuality The new quality of the item after decay.
+--- @return boolean shouldDelete Whether the item should be deleted when quality reaches 0.
+Inventory.CheckItemDecay = function(item, itemInfo, currentTime)
+    itemInfo = itemInfo or RSGCore.Shared.Items[item.name:lower()]
+    currentTime = currentTime or os.time()
+
+    if not itemInfo or not itemInfo.decay then return false, nil, false end
+
+    if not item.info.quality or not item.info.lastUpdate then
+        item.info.quality = item.info.quality or 100
+        item.info.lastUpdate = currentTime
+        return true, item.info.quality, itemInfo.delete == true
+    end
+
+    local timeElapsed = currentTime - item.info.lastUpdate
+    local decayRate = math.round(100 / (itemInfo.decay * 60), 2)
+    local newQuality = math.max(0, math.round(item.info.quality - timeElapsed * decayRate, 0))
+
+    item.info.quality = newQuality
+    item.info.lastUpdate = currentTime
+
+    return true, item.info.quality, itemInfo.delete == true
+end
+
+--- Applies decay to all items in an inventory.
+--- @param items table<number, table> Inventory items (indexed by slot).
+--- @return boolean needsUpdate Returns true if any item was updated or deleted.
+--- @return table removedItems Returns removed items.
+Inventory.CheckItemsDecay = function(items)
+    local needsUpdate = false
+    local currentTime = os.time()
+    local removedItems = {}
+
+    for slot, item in pairs(items) do
+        local updated, quality, delete = Inventory.CheckItemDecay(item, nil, currentTime)
+        if updated then
+            if delete and quality <= 0 then
+                removedItems[slot] = items[slot]
+                items[slot] = nil
+            end
+            needsUpdate = true
+        end
+    end
+
+    return needsUpdate, removedItems
+end
+
+--- Applies decay to all items in a player's inventory and updates their data.
+--- @param player table The player object.
+Inventory.CheckPlayerItemsDecay = function(player)
+    --- @type boolean, table<number, table>
+    local needsUpdate, removedItems = Inventory.CheckItemsDecay(player.PlayerData.items)
+
+    if needsUpdate then
+        player.Functions.SetPlayerData('items', player.PlayerData.items)
+        for _, item in pairs(removedItems) do 
+            TriggerClientEvent('rsg-inventory:client:ItemBox', player.PlayerData.source, RSGCore.Shared.Items[item.name], 'remove', item.amount)
+        end
+    end
+end

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,6 @@
 RSGCore = exports['rsg-core']:GetCoreObject()
+math = lib.math
+
 Inventories = {}
 Drops = {}
 RegisteredShops = {}

--- a/server/shops/events/callbacks.lua
+++ b/server/shops/events/callbacks.lua
@@ -43,6 +43,12 @@ RSGCore.Functions.CreateCallback('rsg-inventory:server:attemptPurchase', functio
         end
 
         for slot, item in ipairs(shopInfo.items) do 
+            if itemInfo.info.quality and itemInfo.info.quality < Config.ShopsMinimumSellQuality then
+                TriggerClientEvent('ox_lib:notify', source, {title = 'The quality of this item is too low!', type = 'error', duration = 5000 })
+                cb(false)
+                return
+            end
+
             if itemInfo.name == item.name and item.price ~= nil then 
                 if Config.ShopsEnableBuybackStockLimit and item.maxStock < (item.amount + amount) then
                     TriggerClientEvent('ox_lib:notify', source, {title = 'This item is fully stocked, shop wont buy more!', type = 'error', duration = 5000 })
@@ -55,7 +61,19 @@ RSGCore.Functions.CreateCallback('rsg-inventory:server:attemptPurchase', functio
                         item.amount = item.amount + amount
                     end
 
-                    local buyprice = tonumber(string.format("%.2f", (item.price * amount) * Config.ShopsBuybackPriceMultiplier))
+                    local buyprice = (item.price * amount) * Config.ShopsBuybackPriceMultiplier
+                    if itemInfo.info.quality and itemInfo.info.quality then 
+                        buyprice = buyprice * (itemInfo.info.quality / 100)
+                    end
+                    
+                    if buyprice < 0.01 then 
+                        TriggerClientEvent('ox_lib:notify', source, {title = 'This is worthless! Try selling a larger quantity.', type = 'error', duration = 5000 })
+                        cb(false)
+                        return
+                    end
+
+                    buyprice = math.round(buyprice, 2)
+
                     Inventory.RemoveItem(source, itemInfo.name, amount, itemInfo.slot, 'shop-sell')
                     Player.Functions.AddMoney('cash', buyprice, 'shop-sell')
                     TriggerClientEvent('rsg-inventory:client:updateInventory', source)

--- a/server/shops/events/callbacks.lua
+++ b/server/shops/events/callbacks.lua
@@ -4,6 +4,7 @@ RSGCore.Functions.CreateCallback('rsg-inventory:server:attemptPurchase', functio
     local shop = string.gsub(data.shop, 'shop%-', '')
     local price = itemInfo.price
     local sinvtype = data.sourceinvtype
+    local targetSlot = data.targetslot
 
     if itemInfo.unique and amount > 1 then
         amount = 1
@@ -97,7 +98,7 @@ RSGCore.Functions.CreateCallback('rsg-inventory:server:attemptPurchase', functio
             end
 
             Player.Functions.RemoveMoney('cash', price, 'shop-purchase')
-            Inventory.AddItem(source, itemInfo.name, amount, nil, itemInfo.info, 'shop-purchase')
+            Inventory.AddItem(source, itemInfo.name, amount, targetSlot, itemInfo.info, 'shop-purchase')
             TriggerClientEvent('rsg-inventory:client:updateInventory', source)
             cb(true)
         else

--- a/server/shops/exports.lua
+++ b/server/shops/exports.lua
@@ -61,6 +61,7 @@ Shops.OpenShop = function(source, name)
         inventory = RegisteredShops[name].items,
         stockEnabled = Config.ShopsStockEnabled,
     }
+    Inventory.CheckPlayerItemsDecay(Player)
     TriggerClientEvent('rsg-inventory:client:openInventory', source, Player.PlayerData.items, formattedInventory)
 end
 

--- a/shared/helpers.lua
+++ b/shared/helpers.lua
@@ -1,5 +1,5 @@
 Helpers = {}
 
-Helpers.CreateDropId = function()
+Helpers.CreateDropId = function(dropId)
     return ('drop-%s'):format(dropId)
 end


### PR DESCRIPTION
## Item decay
- support for `decay` and `delete` options for `RSGCore.Shared.Items`
- whole stack is decaying by same amount
- preventing stacking of items with different qualities
- item buyback price drops with lower quality
#### Example item
```lua
    bread = { 
        name = 'bread',
        label = 'Bread',
        weight = 100, 
        type = 'item', 
        image = 'consumable_bread_roll.png',         
        unique = false, 
        useable = true, 
        shouldClose = true, 
        decay = 120, -- minutes to fully decay
        delete = true, -- should item be deleted when quality decays to 0? only applies to items with decay
        description = 'Bread Roll' 
    },
```
#### New config option
```lua
ShopsMinimumSellQuality = 50, -- shops won't buyback item if item quality drops to this value (set -1 to disable)
```

## UI tweaks
- possible to reorganize inventory while shopping
- possible to sell to shop with dragging
- buying via drag&drop respects target slot
- while dragging, item 'ghost' shows correct amount thats being dragged
- itembox notifications has larger title
- removed quality bar for items without quality
- hotbar reappears when inventory closes
- cleaner hotbar ui
- itembox notification to not overlap with hotbar