### PR TITLE
Shops stock update

### DIFF
--- a/client/ui/callbacks.lua
+++ b/client/ui/callbacks.lua
@@ -47,7 +47,7 @@ RegisterNUICallback('GiveItemAmount', function(data, cb)
     })
 
     if input then
-        cb(tonumber(input[1]))
+        cb(math.abs(tonumber(input[1])))
     end
 end)
 

--- a/config/config.lua
+++ b/config/config.lua
@@ -32,12 +32,7 @@ Config = {
         vector3(-5.000000, -95.000000, -90.000),
     },
 
-    ShopsStockEnabled = true, -- enable of tracking shops item stock
-    ShopsStockPersistent = true, -- should item stock persist or reset after restart
-    ShopsEnableBuyback = true, -- enable shops buying items for fraction of selling price
-    ShopsBuybackPriceMultiplier = 0.1, -- fraction of buyback price (1 = full price, 0.1 = 10% of selling price)
-    ShopsEnableBuybackStockLimit = true, -- shops won't buyback item if default stock amount is reached
-    ShopsMinimumSellQuality = 50, -- shops won't buyback item if item quality drops to this value (set -1 to disable)
+    ShopsRestockCycle = "0 * * * *", -- every hour (https://crontab.guru/)
 
     VendingObjects = {
         `s_inv_whiskey02x`,

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-inventory'
-version '2.2.9'
+version '2.3.0'
 
 shared_scripts {
     '@ox_lib/init.lua',

--- a/html/app.js
+++ b/html/app.js
@@ -74,7 +74,6 @@ const InventoryContainer = Vue.createApp({
                 otherInventoryMaxWeight: 1000000,
                 otherInventorySlots: 100,
                 isShopInventory: false,
-                isShopStockEnabled: false,
                 // Where item is coming from
                 inventory: "",
                 // Context Menu
@@ -180,7 +179,6 @@ const InventoryContainer = Vue.createApp({
 
                 if (this.otherInventoryName.startsWith("shop-")) {
                     this.isShopInventory = true;
-                    this.isShopStockEnabled = data.other.stockEnabled;
                 } else {
                     this.isShopInventory = false;
                 }
@@ -578,7 +576,7 @@ const InventoryContainer = Vue.createApp({
                 return;
             }
 
-            if (this.isShopStockEnabled && sourceItem.amount < 1) {
+            if (sourceItem.amount < 1) {
                 this.inventoryError(sourceSlot);
                 return;
             }
@@ -594,7 +592,7 @@ const InventoryContainer = Vue.createApp({
                 });
 
                 if (response.data) {
-                    if (!this.isShopStockEnabled) {
+                    if (!sourceItem.amount) {
                         this.busy = false;
                         return;
                     }
@@ -603,7 +601,7 @@ const InventoryContainer = Vue.createApp({
                     if (sourceInventoryType == 'player') {
                         for (const key in this.otherInventory) {
                             const item = this.otherInventory[key];
-                            if (item.name == sourceItem.name) {
+                            if (item.name == sourceItem.name && item.amount) {
                                 this.otherInventory[key].amount += amountToTransfer
                                 break
                             }

--- a/html/index.html
+++ b/html/index.html
@@ -94,8 +94,11 @@
                                     x{{ getItemInSlot(slot, 'other').amount }}{{ typeof getItemInSlot(slot, 'other').maxStock === 'number' ? '/' + getItemInSlot(slot, 'other').maxStock : '' }}
                                 </p>
                             </div>
-                            <div v-if="isShopInventory && getItemInSlot(slot, 'other')" class="item-price">
+                            <div v-if="isShopInventory && getItemInSlot(slot, 'other') && getItemInSlot(slot, 'other').price" class="item-price">
                                 <p>${{ getItemInSlot(slot, 'other').price }}</p>
+                            </div>
+                            <div v-if="isShopInventory && getItemInSlot(slot, 'other') && getItemInSlot(slot, 'other').buyPrice" class="item-sell-price">
+                                <p>Sell: ${{ getItemInSlot(slot, 'other').buyPrice }}</p>
                             </div>
                             <div class="item-slot-durability" v-if="getItemInSlot(slot, 'other') && 'quality' in getItemInSlot(slot, 'other').info">
                                 <div

--- a/html/main.css
+++ b/html/main.css
@@ -215,6 +215,20 @@ div {
     justify-content: left;
 }
 
+.item-sell-price {
+    font-size: 1.2vh;
+    font-weight: bolder;
+    color: white;
+    position: absolute;
+    bottom: 5px;
+    left: 5px;
+    width: 50px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: left;
+}
+
 .item-slot-label {
     position: absolute;
     white-space: nowrap;

--- a/server/shops/events/events.lua
+++ b/server/shops/events/events.lua
@@ -2,12 +2,14 @@ RegisterNetEvent('rsg-inventory:server:openVending', function(data)
     local src = source
     local Player = RSGCore.Functions.GetPlayer(src)
     if not Player then return end
-    Inventory.Shops({
-        name = 'vending',
+
+    local key = string.format("%s_%s_%s", data.coords.x, data.coords.y, data.coords.z)
+    Inventory.CreateShop({
+        name = 'vending-'..key,
         label = 'Vending Machine',
         coords = data.coords,
         slots = #Config.VendingItems,
         items = Config.VendingItems
     })
-    Shops.OpenShop(src, 'vending')
+    Shops.OpenShop(src, 'vending-'..key)
 end)

--- a/server/shops/events/handlers.lua
+++ b/server/shops/events/handlers.lua
@@ -1,23 +1,25 @@
 AddEventHandler('txAdmin:events:serverShuttingDown', function()
-    if Config.ShopsStockEnabled and Config.ShopsStockPersistent then
-        Shops.SaveItemsInStock()
-    end
+    Shops.SaveItemsInStock()
 end)
 
 AddEventHandler('onResourceStop', function(resourceName) 
     if resourceName ~= GetCurrentResourceName() then return end
     
-    if Config.ShopsStockEnabled and Config.ShopsStockPersistent then
-        Shops.SaveItemsInStock()
-    end
+    Shops.SaveItemsInStock()
 end)
 
 AddEventHandler('onResourceStart', function(resourceName)
     if resourceName ~= GetCurrentResourceName() then return end
 
-    if Config.ShopsStockEnabled and Config.ShopsStockPersistent then
-        Shops.LoadItemsInStock()
-    else
-        Shops.ClearStockDb()
+    Shops.LoadItemsInStock()
+end)
+
+lib.cron.new(Config.ShopsRestockCycle, function() 
+    for name, shopData in pairs(RegisteredShops) do 
+        for slot, item in pairs(shopData.items) do 
+            if item.restock and item.amount then 
+                item.amount = math.min(item.defaultstock, item.amount + item.restock)
+            end
+        end
     end
 end)


### PR DESCRIPTION
### Config
- removed global shop settings
- added cron expression for restock cycle
```lua
    ShopsRestockCycle = "0 * * * *", -- every hour (https://crontab.guru/)
```

### Added support for more flexible shop settings
- more info in rsg-shops config
```lua
--example shop item settings

-- default bread stock is 50, max stock is 100 so players can sell bread until stock reaches 100
-- minimum bread quality 50 (shop wont buy old bread, if decay is set for bread item)
-- shop will buy bread for 0.05 at full quality. price will be lower for lower quality bread
-- shop will automatically restock 10 bread per hour
{ name = 'bread', amount = 50, price = 0.10, buyPrice = 0.05, maxStock = 100, minQuality = 50, restock = 10 },

-- shop have infinite supply of water, won't buy water from players
{ name = 'water', price = 0.10 },

-- shop will buy any amount of bandages from players, buy wont sell any to players
{ name = 'bandage', buyPrice = 0 },
```

### Restock export
```lua
exports['rsg-inventory']:RestockShop(shopName, percentage) 
-- will restock % of default items stock 
-- can be used for example at end of delivery missions to add extra impact
```

### Fixes & Tweaks
-- fixed dropping/giving negative amounts 
-- buy price added to shop item ui