### PR TITLE
performance, internal shop names fix, remove unused methods

### DIFF
--- a/client/drops/loops.lua
+++ b/client/drops/loops.lua
@@ -39,7 +39,9 @@ CreateThread(function()
                 LocalPlayer.state.dropBagObject = nil
                 LocalPlayer.state.heldDrop = nil
             end
+            Wait(0)
+        else
+            Wait(1000)
         end
-        Wait(0)
     end
 end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -49,7 +49,7 @@ Inventory.NotifyHotbarSpamProtection = function()
     end
 end
 
-Inventory.FormatWeaponAttachments = function(itemdata)
+--[[ Inventory.FormatWeaponAttachments = function(itemdata)
     if not itemdata.info or not itemdata.info.attachments or #itemdata.info.attachments == 0 then
         return {}
     end
@@ -72,5 +72,4 @@ Inventory.FormatWeaponAttachments = function(itemdata)
         end
     end
     return attachments
-end
-
+end ]]

--- a/client/main.lua
+++ b/client/main.lua
@@ -16,45 +16,32 @@ end)
 
 CreateThread(function()
     local commands = {
-        [Config.Keybinds.Open] = "inventory",
-        [Config.Keybinds.Hotbar] = "hotbar"
+        [Config.Keybinds.Open] = { command = "inventory", disabled = false },
+        [Config.Keybinds.Hotbar] = { command = "hotbar", disabled = false },
+        [RSGCore.Shared.Keybinds["1"]] = { command = "slot_1", disabled = true },
+        [RSGCore.Shared.Keybinds["2"]] = { command = "slot_2", disabled = true },
+        [RSGCore.Shared.Keybinds["3"]] = { command = "slot_3", disabled = true },
+        [RSGCore.Shared.Keybinds["4"]] = { command = "slot_4", disabled = true },
+        [RSGCore.Shared.Keybinds["5"]] = { command = "slot_5", disabled = true }
     }
 
     while true do
         Wait(0)
-        for key, command in pairs(commands) do
-            if IsControlJustReleased(0, key) then
-                if Inventory.CanPlayerUseInventory() then
-                    ExecuteCommand(command)
+        for key, data in pairs(commands) do
+            if data.disabled then
+                DisableControlAction(0, key)
+                if IsDisabledControlPressed(0, key) then
+                    if Inventory.CanPlayerUseInventory() then
+                        ExecuteCommand(data.command)
+                    end
+                    break
                 end
-
-                break
-            end
-        end
-    end
-end)
-
-CreateThread(function()
-    local keybinds = RSGCore.Shared.Keybinds
-    local slots = { 
-        ["1"] = "slot_1", 
-        ["2"] = "slot_2", 
-        ["3"] = "slot_3", 
-        ["4"] = "slot_4", 
-        ["5"] = "slot_5"
-     }
-
-    while true do
-        Wait(0)
-
-        for slot, _ in pairs(slots) do
-            DisableControlAction(0, keybinds[slot])
-        end
-        
-        for slot, bind in pairs(slots) do
-            if IsDisabledControlPressed(0, keybinds[slot]) and IsInputDisabled(0) then
-                if Inventory.CanPlayerUseInventory() then
-                    ExecuteCommand(bind)
+            else
+                if IsControlJustReleased(0, key) then
+                    if Inventory.CanPlayerUseInventory() then
+                        ExecuteCommand(data.command)
+                    end
+                    break
                 end
             end
         end

--- a/client/ui/callbacks.lua
+++ b/client/ui/callbacks.lua
@@ -51,7 +51,7 @@ RegisterNUICallback('GiveItemAmount', function(data, cb)
     end
 end)
 
-RegisterNUICallback('GetWeaponData', function(cData, cb)
+--[[ RegisterNUICallback('GetWeaponData', function(cData, cb)
     local data = {
         WeaponData = RSGCore.Shared.Items[cData.weapon],
         AttachmentData = Inventory.FormatWeaponAttachments(cData.ItemData),
@@ -92,4 +92,4 @@ RegisterNUICallback('RemoveAttachment', function(data, cb)
             cb({})
         end
     end, data.AttachmentData, WeaponData)
-end)
+end) ]]

--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -1,4 +1,4 @@
-RegisterNetEvent('rsg-inventory:client:requiredItems', function(items, bool)
+--[[ RegisterNetEvent('rsg-inventory:client:requiredItems', function(items, bool)
     local itemTable = {}
     if bool then
         for k in pairs(items) do
@@ -15,7 +15,7 @@ RegisterNetEvent('rsg-inventory:client:requiredItems', function(items, bool)
         items = itemTable,
         toggle = bool
     })
-end)
+end) ]]
 
 RegisterNetEvent('rsg-inventory:client:hotbar', function(items)
     local token = exports['rsg-core']:GenerateCSRFToken()

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-inventory'
-version '2.4.0'
+version '2.4.1'
 
 shared_scripts {
     '@ox_lib/init.lua',
@@ -53,5 +53,3 @@ files {
     'html/images/*.png',
     'html/*.png',
 }
-
-dependency 'rsg-weapons'

--- a/html/app.js
+++ b/html/app.js
@@ -93,7 +93,7 @@ const InventoryContainer = Vue.createApp({
                 notificationAmount: 1,
                 notificationTimeout: null,
                 // Required items box
-                showRequiredItems: false,
+                //showRequiredItems: false,
                 requiredItems: [],
                 // Attachments
                 selectedWeapon: null,
@@ -898,7 +898,7 @@ const InventoryContainer = Vue.createApp({
                 this.notificationTimeout = null;
             }, 3000);
         },
-        showRequiredItem(data) {
+/*         showRequiredItem(data) {
             if (data.toggle) {
                 this.requiredItems = data.items;
                 this.showRequiredItems = true;
@@ -908,7 +908,7 @@ const InventoryContainer = Vue.createApp({
                     this.requiredItems = [];
                 }, 100);
             }
-        },
+        }, */
         inventoryError(slot) {
             const slotElement = document.getElementById(`slot-${slot}`);
             if (slotElement) {
@@ -937,7 +937,7 @@ const InventoryContainer = Vue.createApp({
                 document.body.removeChild(el);
             }
         },
-        openWeaponAttachments() {
+        /* openWeaponAttachments() {
             if (!this.contextMenuItem) {
                 return;
             }
@@ -988,7 +988,7 @@ const InventoryContainer = Vue.createApp({
                     console.error(error);
                     this.selectedWeaponAttachments.splice(index, 0, attachment);
                 });
-        },
+        }, */
         generateTooltipContent(item) {
             if (!item) {
                 return "";
@@ -1075,9 +1075,9 @@ const InventoryContainer = Vue.createApp({
                 case "itemBox":
                     this.showItemNotification(event.data);
                     break;
-                case "requiredItem":
+/*                 case "requiredItem":
                     this.showRequiredItem(event.data);
-                    break;
+                    break; */
                 case "updateHotbar":
                     if (this.validateToken(event.data.token)) {
                         this.hotbarItems = event.data.items;

--- a/server/shops/events/callbacks.lua
+++ b/server/shops/events/callbacks.lua
@@ -1,7 +1,7 @@
 RSGCore.Functions.CreateCallback('rsg-inventory:server:attemptPurchase', function(source, cb, data)
     local itemInfo = data.item
     local amount = math.round(data.amount)
-    local shop = string.gsub(data.shop, 'shop%-', '')
+    local shop = string.gsub(data.shop, '^shop%-', '')
     local price = itemInfo.price
     local sinvtype = data.sourceinvtype
     local targetSlot = data.targetslot


### PR DESCRIPTION
#### Performance
![image](https://github.com/user-attachments/assets/c2b6dba8-203f-4591-996e-2514aae2e0e1)

#### Shops
- fixed bug where shops names like `some-shop-valentie` would break shop, because of the `shop-` part

#### Cleanup
- commented out some methods that are not used, will be removed from files next iteration
- removed hard dependency on rsg-weapons, since exports are not used. rsg-weapons events are still fired, but they can be processed in any resource (some renaming might take place in future, as origin of event is in inventory and weapons just listen to that event)