### PR TITLE
Create weight and slot usability to be individual for each player

### DIFF
--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -87,12 +87,14 @@ end)
 
 RegisterNetEvent('rsg-inventory:client:openInventory', function(items, other)
     local token = exports['rsg-core']:GenerateCSRFToken()
+    local Player = RSGCore.Functions.GetPlayerData()
+
     SetNuiFocus(true, true)
     SendNUIMessage({
         action = 'open',
         inventory = items,
-        slots = Config.MaxSlots,
-        maxweight = Config.MaxWeight,
+        slots = Player.PlayerData.slots,
+        maxweight = Player.PlayerData.weight,
         other = other,
         token = token,
         closeKey = Config.Keybinds.Close,

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-inventory'
-version '2.4.3'
+version '2.5.0'
 
 shared_scripts {
     '@ox_lib/init.lua',

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -51,7 +51,7 @@ RSGCore.Commands.Add('randomitems', 'Receive random items', {}, false, function(
             amount = 1
         end
         local emptySlot = nil
-        for i = 1, Config.MaxSlots do
+        for i = 1, player.PlayerData.slots do
             if not playerInventory[i] then
                 emptySlot = i
                 break

--- a/server/exports.lua
+++ b/server/exports.lua
@@ -239,7 +239,7 @@ Inventory.GetSlots = function(identifier)
     local player = RSGCore.Functions.GetPlayer(identifier)
     if player then
         inventory = player.PlayerData.items
-        maxSlots = Config.MaxSlots
+        maxSlots = player.PlayerData.slots
     elseif Inventories[identifier] then
         inventory = Inventories[identifier].items
         maxSlots = Inventories[identifier].slots
@@ -299,7 +299,7 @@ Inventory.CanAddItem = function(source, item, amount)
     if not itemData then return false end
     local weight = itemData.weight * amount
     local totalWeight = Inventory.GetTotalWeight(Player.PlayerData.items) + weight
-    if totalWeight > Config.MaxWeight then
+    if totalWeight > Player.PlayerData.weight then
         return false, 'weight'
     end
     local slotsUsed = 0
@@ -308,7 +308,7 @@ Inventory.CanAddItem = function(source, item, amount)
             slotsUsed = slotsUsed + 1
         end
     end
-    if slotsUsed >= Config.MaxSlots then
+    if slotsUsed >= Player.PlayerData.slots then
         return false, 'slots'
     end
     return true
@@ -328,7 +328,7 @@ Inventory.GetFreeWeight = function(source)
     if not Player then return 0 end
 
     local totalWeight = Inventory.GetTotalWeight(Player.PlayerData.items)
-    local freeWeight = Config.MaxWeight - totalWeight
+    local freeWeight = Player.PlayerData.weight - totalWeight
     return freeWeight
 end
 
@@ -433,8 +433,8 @@ Inventory.OpenInventoryById = function(source, targetId)
     local formattedInventory = {
         name = 'otherplayer-' .. targetId,
         label = GetPlayerName(targetId),
-        maxweight = Config.MaxWeight,
-        slots = Config.MaxSlots,
+        maxweight = TargetPlayer.PlayerData.weight,
+        slots = TargetPlayer.PlayerData.slots,
         inventory = targetItems
     }
     Wait(1500)
@@ -528,8 +528,8 @@ Inventory.AddItem = function(identifier, item, amount, slot, info, reason)
 
     if player then
         inventory = player.PlayerData.items
-        inventoryWeight = Config.MaxWeight
-        inventorySlots = Config.MaxSlots
+        inventoryWeight = player.PlayerData.weight
+        inventorySlots = player.PlayerData.slots
     elseif Inventories[identifier] then
         inventory = Inventories[identifier].items
         inventoryWeight = Inventories[identifier].maxweight


### PR DESCRIPTION
This new feature allows players to have different weights/slots from each other. This information is saved in the database along with the player's data.

With these new options, players can use the ChangeWeight and ChangeSlots methods to add or remove weight/slots from their characters. It needs to be released along with the [changes](https://github.com/Rexshack-RedM/rsg-core/pull/62) to rsg-core. 