### PR TITLE
Change access variable, to use direct slots and weight.

### DIFF
--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -93,8 +93,8 @@ RegisterNetEvent('rsg-inventory:client:openInventory', function(items, other)
     SendNUIMessage({
         action = 'open',
         inventory = items,
-        slots = Player.PlayerData.slots,
-        maxweight = Player.PlayerData.weight,
+        slots = Player.slots,
+        maxweight = Player.weight,
         other = other,
         token = token,
         closeKey = Config.Keybinds.Close,


### PR DESCRIPTION
I was accessing Player.PlayerData, but there’s no need since the method already returns the PlayerData directly.