### PR TITLE
Enhance CreateInventory to support updating label, maxweight, and slots if inventory exists

### DIFF
--- a/server/exports.lua
+++ b/server/exports.lua
@@ -769,12 +769,25 @@ end
 
 exports('GetInventory', Inventory.GetInventory)
 
--- Initialize inventory if it doesn't exist
+--- Initialize or update inventory data
 --- @param identifier string - The identifier of the inventory.
 --- @param data table - The data of the inventory
 Inventory.CreateInventory = function (identifier, data)
-    if Inventories[identifier] then return end
-    Inventories[identifier] = Inventory.InitializeInventory(identifier, data)
+    if Inventories[identifier] then 
+        if data.label then
+            Inventories[identifier].label = data.label
+        end
+
+        if data.maxweight then
+            Inventories[identifier].maxweight = data.maxweight
+        end
+
+        if data.slots then
+            Inventories[identifier].slots = data.slots
+        end
+    else
+        Inventories[identifier] = Inventory.InitializeInventory(identifier, data)
+    end
 end
 
 exports('CreateInventory', Inventory.CreateInventory)


### PR DESCRIPTION
### Summary

This pull request improves the `Inventory.CreateInventory` function to support partial updates when an inventory already exists. Previously, the function would return early if the inventory was found, skipping any updates to its data.

### Changes

- If the inventory already exists in `Inventories[identifier]`, and the provided `data` contains any of the following fields:
  - `label`
  - `maxweight`
  - `slots`
  
  These fields will now be overwritten with the new values.

- If the inventory does **not** exist, it will still be initialized using `Inventory.InitializeInventory`, maintaining the original behavior.

### Motivation

This change allows developers to safely re-call `CreateInventory` for existing inventories to update only certain aspects of the inventory's metadata without needing to recreate or manually modify it.

### Compatibility

- Backward-compatible: Existing logic for creating inventories remains unchanged.
- Safe for re-use: Only specified fields in `data` are modified when the inventory exists.

### Example Use Case

```lua
Inventory.CreateInventory("backpackID_1", {
    label = "Backpack",
    maxweight = 100.0
})
-- This will update the existing inventory's label and maxweight without affecting other fields.
