### PR TITLE
Fix shop price and sell price decimal display on Linux (docker)

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -126,10 +126,10 @@
                                 </p>
                             </div>
                             <div v-if="isShopInventory && getItemInSlot(slot, 'other') && getItemInSlot(slot, 'other').price" class="item-price">
-                                <p>${{ getItemInSlot(slot, 'other').price }}</p>
+                                <p>${{ Number(getItemInSlot(slot, 'other').price).toFixed(2) }}</p>
                             </div>
                             <div v-if="isShopInventory && getItemInSlot(slot, 'other') && getItemInSlot(slot, 'other').buyPrice" class="item-sell-price">
-                                <p>Sell: ${{ getItemInSlot(slot, 'other').buyPrice }}</p>
+                                <p>Sell: ${{ Number(getItemInSlot(slot, 'other').buyPrice).toFixed(2) }}/p>
                             </div>
                             <div class="item-slot-durability" v-if="getItemInSlot(slot, 'other') && 'quality' in getItemInSlot(slot, 'other').info">
                                 <div


### PR DESCRIPTION
When running RedM in a Docker container on Linux, shop prices in the inventory UI display too many decimals (e.g. 0.099999999). This issue seems to only occur on Linux, likely due to differences in how the JS/CEF runtime handles floating-point to string conversion compared to Windows.

Changes made:
Applied Number(...).toFixed(2) to shop item price display. 
Applied Number(...).toFixed(2) to shop item sell price (buyPrice) display.
<img width="666" height="367" alt="Capture_decran_2025-08-13_210034" src="https://github.com/user-attachments/assets/a7e19cf2-67e2-44aa-b474-94dac44f29ef" />
