### PR TITLE
Fix Quantity Overlapping (UI)

### DIFF
--- a/html/main.css
+++ b/html/main.css
@@ -376,11 +376,18 @@ div {
     position: absolute;
     top: 0.3vh;
     right: 0.3vh;
-    width: 1.6vh;
+    width: auto;
+    min-width: 1.6vh;
+    max-width: 80%;
     height: 1.6vh;
+    padding: 0 0.3vh;
     display: flex;
     align-items: center;
     justify-content: center;
+}
+.item-slot-amount p {
+    white-space: nowrap;
+    margin: 0;
 }
 .other-inventory .item-slot-amount {
     width: auto;


### PR DESCRIPTION

Basically, when the quantity of an item was too large, for example:
x10000, the value exceeded the slot container.

Now it has a minimum size and adapts as the number grows.
<img width="89" height="92" alt="image" src="https://github.com/user-attachments/assets/39d40fa4-f98c-4e77-acdd-4d055963b95d" />
