### PR TITLE
Add support for cash when it isn’t used solely as an item

### DIFF
--- a/client/ui/events.lua
+++ b/client/ui/events.lua
@@ -26,6 +26,7 @@ RegisterNetEvent('rsg-inventory:client:updateInventory', function()
     SendNUIMessage({
         action = 'update',
         inventory = playerData.items,
+        cash = playerData.money.cash,
         token = token,
     })
 end)
@@ -42,7 +43,7 @@ RegisterNetEvent('rsg-inventory:client:ItemBox', function(itemData, type, amount
             type = type,
             amount = amount
         })
-        
+
         -- Update server hotbar if items were added or removed
         if type == 'remove' or type == 'add' then
             TriggerServerEvent('rsg-inventory:server:updateHotbar')
@@ -86,17 +87,17 @@ RegisterNetEvent('rsg-inventory:client:openInventory', function(items, other)
     local token = exports['rsg-core']:GenerateCSRFToken()
     local Player = RSGCore.Functions.GetPlayerData()
     local config = require 'shared.config'
-
     SetNuiFocus(true, true) -- focus mouse and keyboard on NUI
 
     SendNUIMessage({
-        action = 'open',
-        inventory = items,
-        slots = Player.slots,          -- max inventory slots
-        maxweight = Player.weight,     -- max inventory weight
-        playerId = Player.source or Player.id or Player.citizenid, -- unique player identifier
-        other = other,                 -- context, e.g., trunk inventory
-        token = token,
-        closeKey = config.Keybinds.Close,
+        action              = 'open',
+        inventory           = items,
+        slots               = Player.slots,          -- max inventory slots
+        maxweight           = Player.weight,     -- max inventory weight
+        playerId            = Player.source or Player.id or Player.citizenid, -- unique player identifier
+        other               = other,                 -- context, e.g., trunk inventory
+        token               = token,
+        closeKey            = config.Keybinds.Close,
+        cash                = Player.money.cash,         -- player's money
     })
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,7 +11,6 @@ version '2.6.5'
 
 shared_scripts {
     '@ox_lib/init.lua',
-    '@rsg-core/config.lua',
     'shared/helpers.lua',
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,7 +6,7 @@ lua54 'yes'
 
 description 'rsg-inventory'
 
-version '2.6.4'
+version '2.6.5'
 
 
 shared_scripts {
@@ -52,4 +52,4 @@ files {
     'locales/*.json',
     'html/images/*.png',
     'html/assets/*.*',
-}  
+}

--- a/html/app.js
+++ b/html/app.js
@@ -13,15 +13,7 @@ const InventoryContainer = Vue.createApp({
             return isNaN(weight) ? 0 : weight;
         },
         playerMoney() {
-            let totalMoney = 0;
-            Object.values(this.playerInventory).forEach((item) => {
-                if (item && item.name === 'dollar' && item.amount !== undefined) {
-                    totalMoney += item.amount * 100;
-                } else if (item && item.name === 'cent' && item.amount !== undefined) {
-                    totalMoney += item.amount;
-                }
-            });
-            return totalMoney;
+            return this.cash * 100;
         },
         otherInventoryWeight() {
             const weight = Object.values(this.otherInventory).reduce((total, item) => {
@@ -129,6 +121,7 @@ const InventoryContainer = Vue.createApp({
                 mouseDownX: 0,
                 mouseDownY: 0,
                 scrollBoundElements: [],
+                cash: 0,
             };
         },
         validateToken(csrfToken) {
@@ -158,6 +151,10 @@ const InventoryContainer = Vue.createApp({
             this.playerId = data.playerId || null;
             this.playerInventory = {};
             this.otherInventory = {};
+
+            if (data.cash !== undefined) {
+                this.cash = data.cash;
+            }
 
             if (data.inventory) {
                 if (Array.isArray(data.inventory)) {
@@ -838,7 +835,7 @@ const InventoryContainer = Vue.createApp({
             }
         },
         attachGridScrollListeners() {
-    
+
             if (this.scrollBoundElements && this.scrollBoundElements.length) {
                 this.scrollBoundElements.forEach((el) => {
                     el.removeEventListener('scroll', this.hideItemInfo);
@@ -846,7 +843,7 @@ const InventoryContainer = Vue.createApp({
                 });
             }
             this.scrollBoundElements = [];
-    
+
             const grids = document.querySelectorAll('.item-grid');
             grids.forEach((el) => {
                 el.addEventListener('scroll', this.hideItemInfo, { passive: true });
@@ -1080,16 +1077,16 @@ const InventoryContainer = Vue.createApp({
                 return "";
             }
             let content = `<div class="custom-tooltip"><div class="tooltip-header">${item.label}</div><hr class="tooltip-divider">`;
-        
-            const description = item.info?.description?.replace(/\n/g, "<br>") 
-                || item.description?.replace(/\n/g, "<br>") 
+
+            const description = item.info?.description?.replace(/\n/g, "<br>")
+                || item.description?.replace(/\n/g, "<br>")
                 || "No description available.";
-        
+
             const renderInfo = (obj, indent = 0) => {
                 let html = "";
                 for (const [key, value] of Object.entries(obj)) {
                     if (key === "description" || key === "lastUpdate" || key === "componentshash" || key === "components") continue;
-        
+
                     const padding = "&nbsp;".repeat(indent * 4);
 
                     if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -1101,15 +1098,15 @@ const InventoryContainer = Vue.createApp({
                 }
                 return html;
             };
-            
+
             if (item.info && Object.keys(item.info).length > 0) {
                 content += renderInfo(item.info);
             }
-        
+
             content += `<div class="tooltip-description">${description}</div>`;
             content += `<div class="tooltip-weight"><i class="fas fa-weight-hanging"></i> ${item.weight != null ? (item.weight / 1000).toFixed(1) : "N/A"}kg</div>`;
             content += `</div>`;
-        
+
             return content;
         },
         formatKey(key) {


### PR DESCRIPTION
The current method only checked whether the user had the respective items. If the player chose to use money not as an item, the inventory didn’t handle it properly.