### PR TITLE
Prevent transferring items between players on long distance

### DIFF
--- a/server/drops/events/events.lua
+++ b/server/drops/events/events.lua
@@ -52,7 +52,7 @@ lib.callback.register('rsg-inventory:updateDrop', function(source, dropId, coord
     -- Check if player is close enough to update the drop
     local ped = GetPlayerPed(source)
     local pCoords = GetEntityCoords(ped)
-    if #(pCoords - newCoords) > 5.0 then
+    if #(pCoords - newCoords) > Inventory.MAX_DIST then
         return false, 'error distance'
     end
 

--- a/server/events/callbacks.lua
+++ b/server/events/callbacks.lua
@@ -16,7 +16,7 @@ lib.callback.register('rsg-inventory:server:giveItem', function(source, target, 
     end
 
     -- Check if the distance between source and target is within 5 units
-    if #(GetEntityCoords(GetPlayerPed(source)) - GetEntityCoords(GetPlayerPed(target))) > 5.0 then
+    if #(GetEntityCoords(GetPlayerPed(source)) - GetEntityCoords(GetPlayerPed(target))) > Inventory.MAX_DIST then
         return false
     end
 

--- a/server/shops/exports.lua
+++ b/server/shops/exports.lua
@@ -65,7 +65,7 @@ Shops.OpenShop = function(source, name)
         local shopDistance = vector3(RegisteredShops[name].coords.x, RegisteredShops[name].coords.y, RegisteredShops[name].coords.z)
         if shopDistance then
             local distance = #(playerCoords - shopDistance)
-            if distance > 5.0 then return end
+            if distance > Inventory.MAX_DIST then return end
         end
     end
     local formattedInventory = {


### PR DESCRIPTION
This change restricts item transfers between players, stashes, and drops that are more than 5.0 units apart. The restriction does not apply to actions performed by admins.