### PR TITLE
Use next() instead of # to detect empty table

### DIFF
--- a/server/events/events.lua
+++ b/server/events/events.lua
@@ -25,7 +25,7 @@ RegisterNetEvent('rsg-inventory:server:closeInventory', function(inventory)
     -- Handle dropped item inventories
     if Drops[inventory] then
         Drops[inventory].isOpen = false
-        if #Drops[inventory].items == 0 and not Drops[inventory].isOpen then 
+        if next(Drops[inventory].items) == nil and not Drops[inventory].isOpen then 
             TriggerClientEvent('rsg-inventory:client:removeDropTarget', -1, Drops[inventory].entityId)
             Wait(500)
             local entity = NetworkGetEntityFromNetworkId(Drops[inventory].entityId)


### PR DESCRIPTION
Using `#` to check if Drops are empty returned 0 even when items were present, due to non-numeric keys. This caused valid drops to be deleted. Switched to `next()` for accurate empty table detection.
