### PR TITLE
Item decay fix for high values

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -120,13 +120,13 @@ Inventory.CheckItemDecay = function(item, itemInfo, currentTime)
     end
 
     local timeElapsed = currentTime - item.info.lastUpdate
-    local decayRate = math.round(100 / (itemInfo.decay * 60), 2)
-    local newQuality = math.max(0, math.round(item.info.quality - timeElapsed * decayRate, 0))
+    local decayRate = 100 / (itemInfo.decay * 60)
+    local newQuality = math.max(0, item.info.quality - timeElapsed * decayRate)
 
     item.info.quality = newQuality
     item.info.lastUpdate = currentTime
 
-    return true, item.info.quality, itemInfo.delete == true
+    return true, math.round(newQuality, 1), itemInfo.delete == true
 end
 
 


### PR DESCRIPTION
- Removed rounding from decay rate calculation to prevent it from becoming 0 for high decay values
- Previously, rounding to 2 decimals caused items with decay times > ~3–5 hours to stop decaying entirely
- Now decay calculations use full precision internally and only round on display (e.g. 99.9%)