### PR TITLE
Fix: Prevent overwriting existing inventory data during DB load

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -9,17 +9,28 @@ ShopsStockCache = {}
 
 CreateThread(function()
     MySQL.query('SELECT * FROM inventories', {}, function(result)
-        if result and #result > 0 then
-            for i = 1, #result do
-                local inventory = result[i]
-                local cacheKey = inventory.identifier
-                Inventories[cacheKey] = {
-                    items = json.decode(inventory.items) or {},
+        if not result or #result <= 0 then
+            return
+        end
+
+        for i = 1, #result do
+            local storedInventory = result[i]
+
+            local identifier = storedInventory.identifier
+            local items = json.decode(storedInventory.items) or {}
+
+            local inventory = Inventories[identifier]
+            if not inventory then
+                Inventories[identifier] = {
+                    items = items,
                     isOpen = false
                 }
+            else
+                inventory.items = items
             end
-            print(#result .. ' inventories successfully loaded')
         end
+
+        print(#result .. ' inventories successfully loaded')
     end)
 end)
 


### PR DESCRIPTION
### Changes proposed in this PR:
**Bug Fixes & Logic:**
- Added a check to see if the inventory already exists in `Inventories`.
- If the inventory exists, only update `.items` with database results, preserving runtime properties (e.g. `isOpen` state or data injected by external resources).

**Refactoring & Code Quality:**
- Extracted `json.decode` to a local variable to follow DRY principles.
- Added an early return when database queries return no results to reduce nesting and improve readability.